### PR TITLE
No hard wraps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For best practice we recommend you [authenticate using an API token](https://id.
     -s, --space string         Space in which page should be created
     -t, --title string         Set the page title on upload (defaults to filename without extension)
     -u, --username string      Confluence username. (Alternatively set CONFLUENCE_USERNAME environment variable)
+    -w, --hardwraps            Render newlines as <br />
         --version              version for markdown2confluence
 
 ## Examples

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&m.Endpoint, "endpoint", "e", lib.DefaultEndpoint, "Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable)")
 	rootCmd.PersistentFlags().StringVar(&m.Parent, "parent", "", "Optional parent page to next content under")
 	rootCmd.PersistentFlags().BoolVarP(&m.Debug, "debug", "d", false, "Enable debug logging")
+	rootCmd.PersistentFlags().BoolVarP(&m.WithHardWraps, "hardwraps", "w", false, "Render newlines as <br />")
 	rootCmd.PersistentFlags().IntVarP(&m.Since, "modified-since", "m", 0, "Only upload files that have modifed in the past n minutes")
 	rootCmd.PersistentFlags().StringVarP(&m.Title, "title", "t", "", "Set the page title on upload (defaults to filename without extension)")
 

--- a/lib/file.go
+++ b/lib/file.go
@@ -43,7 +43,7 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
 
 	wikiContent := string(dat)
 	var images []string
-	wikiContent, images, err = renderContent(f.Path, wikiContent)
+	wikiContent, images, err = renderContent(f.Path, wikiContent, m.WithHardWraps)
 
 	if err != nil {
 		return url, fmt.Errorf("unable to render content from %s: %s", f.Path, err)

--- a/lib/markdown.go
+++ b/lib/markdown.go
@@ -33,6 +33,7 @@ type Markdown2Confluence struct {
 	File           string
 	Ancestor       string
 	Debug          bool
+	WithHardWraps  bool
 	Since          int
 	Username       string
 	Password       string
@@ -240,15 +241,21 @@ func validateInput(s string, msg string) {
 
 func renderContent(filePath, s string) (content string, images []string, err error) {
 	confluenceExtension := e.NewConfluenceExtension(filePath)
+	ro := goldmark.WithRendererOptions(
+		html.WithXHTML(),
+	)
+	if m.WithHardWraps {
+		ro = goldmark.WithRendererOptions(
+			html.WithHardWraps(),
+			html.WithXHTML(),
+		)
+	}
 	md := goldmark.New(
 		goldmark.WithExtensions(extension.GFM, extension.DefinitionList),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),
 		),
-		goldmark.WithRendererOptions(
-			html.WithHardWraps(),
-			html.WithXHTML(),
-		),
+		ro,
 		goldmark.WithExtensions(
 			confluenceExtension,
 		),

--- a/lib/markdown.go
+++ b/lib/markdown.go
@@ -239,12 +239,12 @@ func validateInput(s string, msg string) {
 	}
 }
 
-func renderContent(filePath, s string) (content string, images []string, err error) {
+func renderContent(filePath, s string, withHardWraps bool) (content string, images []string, err error) {
 	confluenceExtension := e.NewConfluenceExtension(filePath)
 	ro := goldmark.WithRendererOptions(
 		html.WithXHTML(),
 	)
-	if m.WithHardWraps {
+	if withHardWraps {
 		ro = goldmark.WithRendererOptions(
 			html.WithHardWraps(),
 			html.WithXHTML(),


### PR DESCRIPTION
Added the new option `-w` | `--hardwraps` which enables the current default behavior of introducing `<br />` for linebreaks.

According to markdown standards I think this is wrong behavior so the default with this PR is to **not** render breaks and only enable them when `--hardwraps` is given.