### PR TITLE
enable building markdown2confluence using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.14
+
+WORKDIR /go/src/app
+
+RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+

--- a/README.md
+++ b/README.md
@@ -1,24 +1,51 @@
 # markdown2confluence
+
 Push markdown files to Confluence Cloud
 
 ## Installation
 
-Download the [latest release](https://github.com/justmiles/go-markdown2confluence/releases) and add the binary in your local `PATH`
+Download the [latest
+release](https://github.com/justmiles/go-markdown2confluence/releases)
+and add the binary in your local `PATH`
 
 - Linux
 
-      curl -LO https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.1/go-markdown2confluence_3.1.1_linux_x86_64.tar.gz
-      sudo tar -xzvf go-markdown2confluence_3.1.1_linux_x86_64.tar.gz -C /usr/local/bin/ markdown2confluence
+  ```shell
+  curl -LO https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.2/go-markdown2confluence_3.1.2_linux_x86_64.tar.gz
+  
+  sudo tar -xzvf go-markdown2confluence_3.1.2_linux_x86_64.tar.gz -C /usr/local/bin/ markdown2confluence
+  ```
 
 - OSX
 
-      curl -LO https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.1/go-markdown2confluence_3.1.1_darwin_x86_64.tar.gz
-      sudo tar -xzvf go-markdown2confluence_3.1.1_darwin_x86_64.tar.gz -C /usr/local/bin/ markdown2confluence
+  ```shell
+  curl -LO https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.2/go-markdown2confluence_3.1.2_darwin_x86_64.tar.gz
+  
+  sudo tar -xzvf go-markdown2confluence_3.1.2_darwin_x86_64.tar.gz -C /usr/local/bin/ markdown2confluence
+  ```
 
 - Windows
-  - Download [the latest release](https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.1/go-markdown2confluence_3.1.1_windows_x86_64.tar.gz) and add to your system `PATH`
+  
+  Download [the latest release](https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.2/go-markdown2confluence_3.1.2_windows_x86_64.tar.gz) and add to your system `PATH`
+
+## Build using docker
+
+You can build locally using docker.
+
+### Preparation
+
+```shell
+docker-compose build make
+```
+
+### Building the dist-directory
+
+```shell
+docker-compose run make
+```
 
 ## Environment Variables
+
 For best practice we recommend you [authenticate using an API token](https://id.atlassian.com/manage/api-tokens).
 
 - CONFLUENCE_USERNAME - username for Confluence Cloud. When using API tokens set this to your full email.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: "3.5"
+
+services:
+  make:
+    restart: "no"
+    build:
+      context: .
+    volumes:
+    - .:/src
+    command: /src/make.sh

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+cd $( dirname "$0" )
+echo "Cleaning dist"
+rm -rf dist/*
+echo "Building"
+/go/src/app/bin/goreleaser --snapshot --skip-publish
+if [ -r dist/checksums.txt ] ; then
+    ls -l dist/*.tar.gz
+else
+    echo >&2 "Build failed"
+    exit 1
+fi


### PR DESCRIPTION
Don't know whether or not you're interested, but as I do not want to install too much on my computer I mostly use docker.

Here is my attempt in providing everything required to build markdown2confluence as easy as possible.