### PR TITLE
fix image upload failed

### DIFF
--- a/lib/file.go
+++ b/lib/file.go
@@ -79,7 +79,7 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
 	}
 
 	var content confluence.Content
-
+	var currContentID string
 	// if page exists, update it
 	if len(contentResults) > 0 {
 		content = contentResults[0]
@@ -98,6 +98,7 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
 			return url, fmt.Errorf("Error updating content: %s", err)
 		}
 		url = m.client.Endpoint + content.Links.Tinyui
+		currContentID = content.ID
 
 		// if page does not exist, create it
 	} else {
@@ -120,11 +121,12 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
 			return url, fmt.Errorf("Error creating page: %s", err)
 		}
 		url = m.client.Endpoint + content.Links.Tinyui
+		currContentID = content.ID
 	}
 
-	// fmt.Println(content)
+	fmt.Println("content.ID = " + content.ID + " content_id = " + currContentID)
 
-	_, errors := m.client.AddUpdateAttachments(content.ID, images)
+	_, errors := m.client.AddUpdateAttachments(currContentID, images)
 	if len(errors) > 0 {
 		fmt.Println(errors)
 		err = errors[0]

--- a/lib/file.go
+++ b/lib/file.go
@@ -17,7 +17,7 @@ type MarkdownFile struct {
 	Ancestor string
 }
 
-func (f *MarkdownFile) String() (link string) {
+func (f *MarkdownFile) String() (urlPath string) {
 	return fmt.Sprintf("Path: %s, Title: %s, Parent: %s, Ancestor: %s", f.Path, f.Title, f.Parents, f.Ancestor)
 }
 
@@ -30,12 +30,12 @@ func (f *MarkdownFile) FormattedPath() (s string) {
 }
 
 // Upload a markdown file
-func (f *MarkdownFile) Upload(m *Markdown2Confluence) (link string, err error) {
+func (f *MarkdownFile) Upload(m *Markdown2Confluence) (urlPath string, err error) {
 	var ancestorID string
 	// Content of Wiki
 	dat, err := ioutil.ReadFile(f.Path)
 	if err != nil {
-		return link, fmt.Errorf("Could not open file %s:\n\t%s", f.Path, err)
+		return urlPath, fmt.Errorf("Could not open file %s:\n\t%s", f.Path, err)
 	}
 
 	if m.Debug {
@@ -48,7 +48,7 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (link string, err error) {
 	wikiContent, images, err = renderContent(f.Path, wikiContent, m.WithHardWraps)
 
 	if err != nil {
-		return link, fmt.Errorf("unable to render content from %s: %s", f.Path, err)
+		return urlPath, fmt.Errorf("unable to render content from %s: %s", f.Path, err)
 	}
 
 	if m.Debug {
@@ -70,13 +70,13 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (link string, err error) {
 		Expand:   []string{"version", "body.storage"},
 	})
 	if err != nil {
-		return link, fmt.Errorf("Error checking for existing page: %s", err)
+		return urlPath, fmt.Errorf("Error checking for existing page: %s", err)
 	}
 
 	if len(f.Parents) > 0 {
 		ancestorID, err = f.FindOrCreateAncestors(m)
 		if err != nil {
-			return link, err
+			return urlPath, err
 		}
 	}
 
@@ -97,9 +97,9 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (link string, err error) {
 
 		content, err = m.client.UpdateContent(&content, nil)
 		if err != nil {
-			return link, fmt.Errorf("Error updating content: %s", err)
+			return urlPath, fmt.Errorf("Error updating content: %s", err)
 		}
-		link = m.client.Endpoint + content.Links.Tinyui
+		urlPath = m.client.Endpoint + content.Links.Tinyui
 		currContentID = content.ID
 
 		// if page does not exist, create it
@@ -120,9 +120,9 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (link string, err error) {
 
 		content, err := m.client.CreateContent(&bp, nil)
 		if err != nil {
-			return link, fmt.Errorf("Error creating page: %s", err)
+			return urlPath, fmt.Errorf("Error creating page: %s", err)
 		}
-		link = m.client.Endpoint + content.Links.Tinyui
+		urlPath = m.client.Endpoint + content.Links.Tinyui
 		currContentID = content.ID
 	}
 
@@ -134,7 +134,7 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (link string, err error) {
 		err = errors[0]
 	}
 
-	return link, err
+	return urlPath, err
 }
 
 // FindOrCreateAncestors creates an empty page to represent a local "folder" name

--- a/lib/file.go
+++ b/lib/file.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"strings"
 
 	"github.com/justmiles/go-confluence"
@@ -16,7 +17,7 @@ type MarkdownFile struct {
 	Ancestor string
 }
 
-func (f *MarkdownFile) String() (url string) {
+func (f *MarkdownFile) String() (link string) {
 	return fmt.Sprintf("Path: %s, Title: %s, Parent: %s, Ancestor: %s", f.Path, f.Title, f.Parents, f.Ancestor)
 }
 
@@ -29,24 +30,25 @@ func (f *MarkdownFile) FormattedPath() (s string) {
 }
 
 // Upload a markdown file
-func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
+func (f *MarkdownFile) Upload(m *Markdown2Confluence) (link string, err error) {
 	var ancestorID string
 	// Content of Wiki
 	dat, err := ioutil.ReadFile(f.Path)
 	if err != nil {
-		return url, fmt.Errorf("Could not open file %s:\n\t%s", f.Path, err)
+		return link, fmt.Errorf("Could not open file %s:\n\t%s", f.Path, err)
 	}
 
 	if m.Debug {
 		fmt.Println(f.Path)
 	}
 
-	wikiContent := string(dat)
+	//unescape unicode path  %xx -> unicode word for some markdown software make escape
+	wikiContent, _ := url.QueryUnescape(string(dat))
 	var images []string
 	wikiContent, images, err = renderContent(f.Path, wikiContent, m.WithHardWraps)
 
 	if err != nil {
-		return url, fmt.Errorf("unable to render content from %s: %s", f.Path, err)
+		return link, fmt.Errorf("unable to render content from %s: %s", f.Path, err)
 	}
 
 	if m.Debug {
@@ -68,13 +70,13 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
 		Expand:   []string{"version", "body.storage"},
 	})
 	if err != nil {
-		return url, fmt.Errorf("Error checking for existing page: %s", err)
+		return link, fmt.Errorf("Error checking for existing page: %s", err)
 	}
 
 	if len(f.Parents) > 0 {
 		ancestorID, err = f.FindOrCreateAncestors(m)
 		if err != nil {
-			return url, err
+			return link, err
 		}
 	}
 
@@ -95,9 +97,9 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
 
 		content, err = m.client.UpdateContent(&content, nil)
 		if err != nil {
-			return url, fmt.Errorf("Error updating content: %s", err)
+			return link, fmt.Errorf("Error updating content: %s", err)
 		}
-		url = m.client.Endpoint + content.Links.Tinyui
+		link = m.client.Endpoint + content.Links.Tinyui
 		currContentID = content.ID
 
 		// if page does not exist, create it
@@ -118,9 +120,9 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
 
 		content, err := m.client.CreateContent(&bp, nil)
 		if err != nil {
-			return url, fmt.Errorf("Error creating page: %s", err)
+			return link, fmt.Errorf("Error creating page: %s", err)
 		}
-		url = m.client.Endpoint + content.Links.Tinyui
+		link = m.client.Endpoint + content.Links.Tinyui
 		currContentID = content.ID
 	}
 
@@ -132,7 +134,7 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (url string, err error) {
 		err = errors[0]
 	}
 
-	return url, err
+	return link, err
 }
 
 // FindOrCreateAncestors creates an empty page to represent a local "folder" name

--- a/lib/renderer/image.go
+++ b/lib/renderer/image.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -101,12 +102,17 @@ func RenderImageAttributes(w util.BufWriter, node ast.Node, filter util.BytesFil
 func localFile(filePath string, destination []byte) (string, error) {
 
 	localizedPath := string(destination)
-	if _, err := os.Stat(localizedPath); err == nil {
+	_, err := os.Stat(localizedPath)
+	if err == nil {
 		return localizedPath, nil
 	}
 
-	localizedPath = path.Join(path.Dir(filePath), string(destination))
-	if _, err := os.Stat(localizedPath); err == nil {
+	//path.Dir currDir is workpath so "path.Dir is '.'"
+	//And so make a absolute path for check file
+	localizedAbsPath, _ := filepath.Abs(filePath)
+	localizedPath = path.Join(filepath.Dir(localizedAbsPath), string(destination))
+	_, err = os.Stat(localizedPath)
+	if err == nil {
 		return localizedPath, nil
 	}
 


### PR DESCRIPTION
When I use this tool upload markdown files to confluence.   It alway not show the picture.  I founded 2  anomalous place when debug that

1.  When out namespace "if" block Content.ID  will be override to None   lead to picture upload failed (No target content ID).

2.  Some markdown tools will escape unicode path when add pictures to file.  But goldmark process to <img ...> tag  not <ac:...> tag for these path,.

3.  if pictures absoulte path is not same the markdown file.  The picture will not found in relative path