### PR TITLE
added support for exclude-filters, nested parents and document titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and add the binary in your local `PATH`
 
   ```shell
   curl -LO https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.2/go-markdown2confluence_3.1.2_linux_x86_64.tar.gz
-  
+
   sudo tar -xzvf go-markdown2confluence_3.1.2_linux_x86_64.tar.gz -C /usr/local/bin/ markdown2confluence
   ```
 
@@ -20,12 +20,12 @@ and add the binary in your local `PATH`
 
   ```shell
   curl -LO https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.2/go-markdown2confluence_3.1.2_darwin_x86_64.tar.gz
-  
+
   sudo tar -xzvf go-markdown2confluence_3.1.2_darwin_x86_64.tar.gz -C /usr/local/bin/ markdown2confluence
   ```
 
 - Windows
-  
+
   Download [the latest release](https://github.com/justmiles/go-markdown2confluence/releases/download/v3.1.2/go-markdown2confluence_3.1.2_windows_x86_64.tar.gz) and add to your system `PATH`
 
 ## Use with Docker
@@ -54,20 +54,22 @@ For best practice we recommend you [authenticate using an API token](https://id.
 Push markdown files to Confluence Cloud
 
 Usage:
-markdown2confluence [flags] (files or directories)
+  markdown2confluence [flags]
 
 Flags:
--d, --debug                Enable debug logging
--e, --endpoint string      Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable) (default "https://mydomain.atlassian.net/wiki")
--h, --help                 help for markdown2confluence
--m, --modified-since int   Only upload files that have modifed in the past n minutes
-    --parent string        Optional parent page to nest content under
--p, --password string      Confluence password. (Alternatively set CONFLUENCE_PASSWORD environment variable)
--s, --space string         Space in which page should be created
--t, --title string         Set the page title on upload (defaults to filename without extension)
--u, --username string      Confluence username. (Alternatively set CONFLUENCE_USERNAME environment variable)
--w, --hardwraps            Render newlines as <br />
-    --version              version for markdown2confluence
+  -d, --debug                Enable debug logging
+  -e, --endpoint string      Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable) (default "https://mydomain.atlassian.net/wiki")
+  -x, --exclude strings      list of exclude file patterns (regex) that will be applied on markdown file paths
+  -w, --hardwraps            Render newlines as <br />
+  -h, --help                 help for markdown2confluence
+  -m, --modified-since int   Only upload files that have modifed in the past n minutes
+      --parent string        Optional parent page to next content under
+  -p, --password string      Confluence password. (Alternatively set CONFLUENCE_PASSWORD environment variable)
+  -s, --space string         Space in which page should be created
+  -t, --title string         Set the page title on upload (defaults to filename without extension)
+      --use-document-title   Will use the Markdown document title (# Title) if available
+  -u, --username string      Confluence username. (Alternatively set CONFLUENCE_USERNAME environment variable)
+      --version              version for markdown2confluence
 ```
 
 ## Examples
@@ -75,25 +77,56 @@ Flags:
 Upload a local directory of markdown files called `markdown-files` to Confluence.
 
 ```shell
-markdown2confluence --space 'MyTeamSpace' markdown-files
+markdown2confluence \
+  --space 'MyTeamSpace' \
+  markdown-files
 ```
 
 Upload the same directory, but only those modified in the last 30 minutes. This is particurlarly useful for cron jobs/recurring one-way syncs.
 
 ```shell
-markdown2confluence --space 'MyTeamSpace' --modified-since 30 markdown-files
+markdown2confluence \
+  --space 'MyTeamSpace' \
+  --modified-since 30 \
+  markdown-files
 ```
 
 Upload a single file
 
 ```shell
-markdown2confluence --space 'MyTeamSpace' markdown-files/test.md
+markdown2confluence \
+  --space 'MyTeamSpace' \
+  markdown-files/test.md
 ```
 
 Upload a directory of markdown files in space `MyTeamSpace` under the parent page `API Docs`
 
 ```shell
-markdown2confluence --space 'MyTeamSpace' --parent 'API Docs' markdown-files
+markdown2confluence \
+  --space 'MyTeamSpace' \
+  --parent 'API Docs' \
+  markdown-files
+```
+
+Upload a directory of markdown files in space `MyTeamSpace` under a _nested_ parent page `Docs/API` and _exclude_ mardown files/directories that match `.*generated.*` or `.*temp.md`
+
+```shell
+markdown2confluence \
+  --space 'MyTeamSpace' \
+  --parent 'API/Docs' \
+  --exclude '.*generated.*' \
+  --exclude '.*temp.md' \
+   markdown-files
+```
+
+Upload a directory of markdown files in space `MyTeamSpace` under the parent page  `API Docs` and use the markdown _document-title_ instead of the filname as document title (if available) in Confluence.
+
+```shell
+markdown2confluence \
+  --space 'MyTeamSpace' \
+  --parent 'API Docs' \
+  --use-document-title \
+   markdown-files
 ```
 
 ## Enhancements

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,10 +22,11 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&m.Endpoint, "endpoint", "e", lib.DefaultEndpoint, "Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable)")
 	rootCmd.PersistentFlags().StringVar(&m.Parent, "parent", "", "Optional parent page to next content under")
 	rootCmd.PersistentFlags().BoolVarP(&m.Debug, "debug", "d", false, "Enable debug logging")
+	rootCmd.PersistentFlags().BoolVarP(&m.UseDocumentTitle, "use-document-title", "", false, "Will use the Markdown document title (# Title) if available")
 	rootCmd.PersistentFlags().BoolVarP(&m.WithHardWraps, "hardwraps", "w", false, "Render newlines as <br />")
 	rootCmd.PersistentFlags().IntVarP(&m.Since, "modified-since", "m", 0, "Only upload files that have modifed in the past n minutes")
 	rootCmd.PersistentFlags().StringVarP(&m.Title, "title", "t", "", "Set the page title on upload (defaults to filename without extension)")
-
+	rootCmd.PersistentFlags().StringSliceVarP(&m.ExcludeFilePatterns, "exclude", "x", []string{}, "list of exclude file patterns (regex) for that will be applied on markdown file paths")
 	m.SourceEnvironmentVariables()
 
 }


### PR DESCRIPTION
Hey Miles,

I stumbled upon your projects just a few days ago and did try to use it for our DevOps workflows. While it is already pretty neat, I was missing some important functionality to make it easier to integrate it into our pipelines. I took the liberty to modify your sources to support the following additional features

- Support nested parents
- Add exclude filter options to exclude files when using the tool in directory mode
- Add support to used the markdown document's title (# Title) instead of the filename

I added the necessary documentation into the README.md
There should not be any breaking changes, but since before this I never worked with `go` before - please have a good look at the code changes and let me know if I should do adaptions.

Best,
Matthias