### PR TITLE
#19: Follow links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ env.sh
 debug
 build
 dist
-.vscode
 *.code-workspace
 .envrc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Tests",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "env": {},
+            "args": [
+                "--username", "",
+                "--password", "",
+                "--endpoint", "",
+                "--space=SAN",
+                "--parent=markdown/deep/deeper",
+                "--use-document-title",
+                "--follow-links",
+                "-x=.*vendor/.*",
+                "-x=.*excluded.md",
+                "${workspaceFolder}/tests/README.md"
+            ]
+        },
+        {
+            "name": "Help",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "env": {},
+            "args": [
+                "--help"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Usage:
 Flags:
   -d, --debug                Enable debug logging
   -e, --endpoint string      Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable) (default "https://mydomain.atlassian.net/wiki")
-  -x, --exclude strings      list of exclude file patterns (regex) that will be applied on markdown file paths
+  -x, --exclude strings      list of exclude file patterns (regex) for that will be applied on markdown file paths
+      --follow-links         If enabled, documents linked (relative) will be followed and uploaded to conflunece as well
   -w, --hardwraps            Render newlines as <br />
   -h, --help                 help for markdown2confluence
   -m, --modified-since int   Only upload files that have modifed in the past n minutes
@@ -116,7 +117,7 @@ markdown2confluence \
   --parent 'API/Docs' \
   --exclude '.*generated.*' \
   --exclude '.*temp.md' \
-   markdown-files
+  markdown-files
 ```
 
 Upload a directory of markdown files in space `MyTeamSpace` under the parent page  `API Docs` and use the markdown _document-title_ instead of the filname as document title (if available) in Confluence.
@@ -126,9 +127,19 @@ markdown2confluence \
   --space 'MyTeamSpace' \
   --parent 'API Docs' \
   --use-document-title \
-   markdown-files
+  markdown-files
 ```
 
+The following snippet will also upload markdown documents that are _relatively_ linked. The relative order of the files will be kept within the confluence space.
+
+```shell
+markdown2confluence \
+  --follow-links \
+  --space 'MyTeamSpace' \
+  --parent 'API Docs' \
+  --use-document-title \
+  README.md
+```
 ## Enhancements
 
 It is possible to insert Confluence macros using fenced code blocks.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&m.Parent, "parent", "", "Optional parent page to next content under")
 	rootCmd.PersistentFlags().BoolVarP(&m.Debug, "debug", "d", false, "Enable debug logging")
 	rootCmd.PersistentFlags().BoolVarP(&m.UseDocumentTitle, "use-document-title", "", false, "Will use the Markdown document title (# Title) if available")
+	rootCmd.PersistentFlags().BoolVarP(&m.FollowLinks, "follow-links", "", false, "If enabled, documents linked (relative) will be followed and uploaded to conflunece as well")
 	rootCmd.PersistentFlags().BoolVarP(&m.WithHardWraps, "hardwraps", "w", false, "Render newlines as <br />")
 	rootCmd.PersistentFlags().IntVarP(&m.Since, "modified-since", "m", 0, "Only upload files that have modifed in the past n minutes")
 	rootCmd.PersistentFlags().StringVarP(&m.Title, "title", "t", "", "Set the page title on upload (defaults to filename without extension)")

--- a/lib/file.go
+++ b/lib/file.go
@@ -15,6 +15,7 @@ type MarkdownFile struct {
 	Title    string
 	Parents  []string
 	Ancestor string
+	URL      string
 }
 
 func (f *MarkdownFile) String() (urlPath string) {

--- a/lib/file.go
+++ b/lib/file.go
@@ -126,8 +126,6 @@ func (f *MarkdownFile) Upload(m *Markdown2Confluence) (urlPath string, err error
 		currContentID = content.ID
 	}
 
-	fmt.Println("content.ID = " + content.ID + " content_id = " + currContentID)
-
 	_, errors := m.client.AddUpdateAttachments(currContentID, images)
 	if len(errors) > 0 {
 		fmt.Println(errors)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# This is the Root
+
+## Markdown with links
+
+This is a [GitHubLink](https://github.com/user/repo/blob/branch/other_file.md) that will not be replaced
+
+This [relative path](component/COMPONENT_A.md) to `COMPONENT A` should be placed into `component/COMPONENT A`

--- a/tests/component/COMPONENT_A.md
+++ b/tests/component/COMPONENT_A.md
@@ -1,0 +1,7 @@
+# COMPONENT A
+
+This is a [link](https://github.com/user/repo/blob/branch/other_file.md) that won't be replaced
+
+This [Component B](COMPONENT_B.md) will be next to this file
+
+And this goes back to the [root](../README.md)

--- a/tests/component/COMPONENT_A.md
+++ b/tests/component/COMPONENT_A.md
@@ -5,3 +5,8 @@ This is a [link](https://github.com/user/repo/blob/branch/other_file.md) that wo
 This [Component B](COMPONENT_B.md) will be next to this file
 
 And this goes back to the [root](../README.md)
+
+[You can use numbers for reference-style link definitions][1]
+
+
+[1]: ../README.md

--- a/tests/component/COMPONENT_B.md
+++ b/tests/component/COMPONENT_B.md
@@ -1,0 +1,5 @@
+# COMPONENT B
+
+Refence to [Component a](COMPONENT_A.md) that lives next to this document
+
+Reference back to [README.md](../../README.md)

--- a/tests/component/COMPONENT_B.md
+++ b/tests/component/COMPONENT_B.md
@@ -2,4 +2,4 @@
 
 Refence to [Component a](COMPONENT_A.md) that lives next to this document
 
-Reference back to [README.md](../../README.md)
+Reference back to [README.md](../README.md)


### PR DESCRIPTION
Hey there,

I took a shot at implementing the `follow links` feature. Again, I'm not a `Golang` expert so please have a good look at the implementation.

I had to refactor the one or the other function a bit, to make it better suitable for the approach I'm using. I decided to do a two-step approach, with

1. Find all relative paths within the markdown files
2. Upload all of those files relative to the file they were mentioned
3. Store the returned urls
4. Patch all markdown files with the retrieved confluence urls
5. Re-upload them to confluence

It is working for me so far, but for sure there might be some corner cases I did not think of. Please test this out and let me know if it works as expected.

Cheers,
Matthias