### PR TITLE
Use alpine image to make K8s ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o markdown2confluence -ldf
 RUN md5sum markdown2confluence
 
 # Create image from scratch
-FROM scratch
+FROM alpine
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/markdown2confluence /markdown2confluence


### PR DESCRIPTION
I can't use this tool, since it can not be deployed within a pod and being idle (e.g. sleep 10000).