### PR TITLE
[feature] add access_token support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 .vscode
 *.code-workspace
 .envrc
+.idea/
+***/*.secret

--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ docker run -v $PWD:/src -w /src goreleaser/goreleaser --snapshot --skip-publish 
 
 For best practice we recommend you [authenticate using an API token](https://id.atlassian.com/manage/api-tokens).
 
+However, you may also use [Personal Access Tokens](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html),
+which may help if your company uses SSO.
+
 - CONFLUENCE_USERNAME - username for Confluence Cloud. When using API tokens set this to your full email.
 - CONFLUENCE_PASSWORD - API token or password for Confluence Cloud
 - CONFLUENCE_ENDPOINT - endpoint for Confluence Cloud, eg `https://mycompanyname.atlassian.net/wiki`
-
+- CONFLUENCE_ACCESS_TOKEN - Bearer access token to use (instead of API token)
+- 
 ## Usage
 
 ```txt
@@ -57,20 +61,21 @@ Usage:
   markdown2confluence [flags]
 
 Flags:
-  -d, --debug                Enable debug logging
-  -e, --endpoint string      Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable) (default "https://mydomain.atlassian.net/wiki")
-  -x, --exclude strings      list of exclude file patterns (regex) that will be applied on markdown file paths
-  -w, --hardwraps            Render newlines as <br />
-  -h, --help                 help for markdown2confluence
-  -m, --modified-since int   Only upload files that have modifed in the past n minutes
-      --parent string        Optional parent page to next content under
-  -p, --password string      Confluence password. (Alternatively set CONFLUENCE_PASSWORD environment variable)
-  -s, --space string         Space in which page should be created
-  -c, --comment string       Add a comment to the page (optional)
-  -t, --title string         Set the page title on upload (defaults to filename without extension)
-      --use-document-title   Will use the Markdown document title (# Title) if available
-  -u, --username string      Confluence username. (Alternatively set CONFLUENCE_USERNAME environment variable)
-      --version              version for markdown2confluence
+  -a, --access-token string   Confluence access-token. (Alternatively set CONFLUENCE_ACCESS_TOKEN environment variable)
+  -c, --comment string        (Optional) Add comment to page
+  -d, --debug                 Enable debug logging
+  -e, --endpoint string       Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable) (default "https://mydomain.atlassian.net/wiki")
+  -x, --exclude strings       list of exclude file patterns (regex) for that will be applied on markdown file paths
+  -w, --hardwraps             Render newlines as <br />
+  -h, --help                  help for markdown2confluence
+  -m, --modified-since int    Only upload files that have modifed in the past n minutes
+      --parent string         Optional parent page to next content under
+  -p, --password string       Confluence password. (Alternatively set CONFLUENCE_PASSWORD environment variable)
+  -s, --space string          Space in which page should be created
+  -t, --title string          Set the page title on upload (defaults to filename without extension)
+      --use-document-title    Will use the Markdown document title (# Title) if available
+  -u, --username string       Confluence username. (Alternatively set CONFLUENCE_USERNAME environment variable)
+      --version               version for markdown2confluence
 ```
 
 ## Examples

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&m.Comment, "comment", "c", "", "(Optional) Add comment to page")
 	rootCmd.PersistentFlags().StringVarP(&m.Username, "username", "u", "", "Confluence username. (Alternatively set CONFLUENCE_USERNAME environment variable)")
 	rootCmd.PersistentFlags().StringVarP(&m.Password, "password", "p", "", "Confluence password. (Alternatively set CONFLUENCE_PASSWORD environment variable)")
+	rootCmd.PersistentFlags().StringVarP(&m.AccessToken, "access-token", "a", "", "Confluence access-token. (Alternatively set CONFLUENCE_ACCESS_TOKEN environment variable)")
 	rootCmd.PersistentFlags().StringVarP(&m.Endpoint, "endpoint", "e", lib.DefaultEndpoint, "Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable)")
 	rootCmd.PersistentFlags().StringVar(&m.Parent, "parent", "", "Optional parent page to next content under")
 	rootCmd.PersistentFlags().BoolVarP(&m.Debug, "debug", "d", false, "Enable debug logging")

--- a/confluence.secret.sample
+++ b/confluence.secret.sample
@@ -1,0 +1,4 @@
+export CONFLUENCE_USERNAME=jwick@blacksuit.com
+export CONFLUENCE_PASSWORD=bullets
+export CONFLUENCE_ENDPOINT=https://mycompanyname.atlassian.net/wiki
+export CONFLUENCE_PERSONAL_ACCESS_TOKEN=DEADBEEF

--- a/lib/markdown.go
+++ b/lib/markdown.go
@@ -42,6 +42,7 @@ type Markdown2Confluence struct {
 	Since               int
 	Username            string
 	Password            string
+	AccessToken         string
 	Endpoint            string
 	Parent              string
 	SourceMarkdown      []string
@@ -54,6 +55,7 @@ func (m *Markdown2Confluence) CreateClient() {
 	m.client = new(confluence.Client)
 	m.client.Username = m.Username
 	m.client.Password = m.Password
+	m.client.AccessToken = m.AccessToken
 	m.client.Endpoint = m.Endpoint
 	m.client.Debug = m.Debug
 }
@@ -74,6 +76,11 @@ func (m *Markdown2Confluence) SourceEnvironmentVariables() {
 		m.Password = s
 	}
 
+	s = os.Getenv("CONFLUENCE_ACCESS_TOKEN")
+	if s != "" {
+		m.AccessToken = s
+	}
+
 	s = os.Getenv("CONFLUENCE_ENDPOINT")
 	if s != "" {
 		m.Endpoint = s
@@ -85,10 +92,10 @@ func (m Markdown2Confluence) Validate() error {
 	if m.Space == "" {
 		return fmt.Errorf("--space is not defined")
 	}
-	if m.Username == "" {
+	if m.Username == "" && m.AccessToken == "" {
 		return fmt.Errorf("--username is not defined")
 	}
-	if m.Password == "" {
+	if m.Password == "" && m.AccessToken == "" {
 		return fmt.Errorf("--password is not defined")
 	}
 	if m.Endpoint == "" {
@@ -102,6 +109,9 @@ func (m Markdown2Confluence) Validate() error {
 	}
 	if len(m.SourceMarkdown) > 1 && m.Title != "" {
 		return fmt.Errorf("You can not set the title for multiple files")
+	}
+	if m.AccessToken == "" && m.Username == "" {
+		return fmt.Errorf("--access-token is not defined")
 	}
 	return nil
 }


### PR DESCRIPTION
## Overview
This simply adds support for [Personal Access Tokens](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) in Confluence.

## Dependencies
- https://github.com/justmiles/go-confluence/pull/2