### PR TITLE
Added -i parameter to allow for insecure skipping of tls-verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Flags:
   -x, --exclude strings       list of exclude file patterns (regex) for that will be applied on markdown file paths
   -w, --hardwraps             Render newlines as <br />
   -h, --help                  help for markdown2confluence
+  -i, --insecuretls           Skip certificate validation. (e.g. for self-signed certificates)
   -m, --modified-since int    Only upload files that have modifed in the past n minutes
       --parent string         Optional parent page to next content under
   -p, --password string       Confluence password. (Alternatively set CONFLUENCE_PASSWORD environment variable)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 
 	lib "github.com/justmiles/go-markdown2confluence/lib"
@@ -22,6 +24,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&m.Password, "password", "p", "", "Confluence password. (Alternatively set CONFLUENCE_PASSWORD environment variable)")
 	rootCmd.PersistentFlags().StringVarP(&m.AccessToken, "access-token", "a", "", "Confluence access-token. (Alternatively set CONFLUENCE_ACCESS_TOKEN environment variable)")
 	rootCmd.PersistentFlags().StringVarP(&m.Endpoint, "endpoint", "e", lib.DefaultEndpoint, "Confluence endpoint. (Alternatively set CONFLUENCE_ENDPOINT environment variable)")
+	rootCmd.PersistentFlags().BoolVarP(&m.InsecureTLS, "insecuretls", "i", false, "Skip certificate validation. (e.g. for self-signed certificates)")
 	rootCmd.PersistentFlags().StringVar(&m.Parent, "parent", "", "Optional parent page to next content under")
 	rootCmd.PersistentFlags().BoolVarP(&m.Debug, "debug", "d", false, "Enable debug logging")
 	rootCmd.PersistentFlags().BoolVarP(&m.UseDocumentTitle, "use-document-title", "", false, "Will use the Markdown document title (# Title) if available")
@@ -43,6 +46,10 @@ var rootCmd = &cobra.Command{
 		err := m.Validate()
 		if err != nil {
 			log.Fatal(err)
+		}
+		if m.InsecureTLS {
+			fmt.Println("Warning: TLS verification is disabled. This allows for man-in-the-middle-attacks.")
+			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		}
 
 		errors := m.Run()

--- a/lib/markdown.go
+++ b/lib/markdown.go
@@ -43,6 +43,7 @@ type Markdown2Confluence struct {
 	Username            string
 	Password            string
 	AccessToken         string
+	InsecureTLS         bool
 	Endpoint            string
 	Parent              string
 	SourceMarkdown      []string
@@ -50,7 +51,7 @@ type Markdown2Confluence struct {
 	client              *confluence.Client
 }
 
-// CreateClient returns a new markdown clietn
+// CreateClient returns a new markdown client
 func (m *Markdown2Confluence) CreateClient() {
 	m.client = new(confluence.Client)
 	m.client.Username = m.Username


### PR DESCRIPTION
This PR allows to use the '-i' parameter which disables tls-verification globally for all https requests.